### PR TITLE
Improve Windows GUI stability

### DIFF
--- a/cmd/win-gui/main.go
+++ b/cmd/win-gui/main.go
@@ -35,6 +35,11 @@ func main() {
 	}
 	defer logFile.Close()
 	log.SetOutput(logFile)
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("panic: %v", r)
+		}
+	}()
 
 	log.Println("Starting Tailscale GUI...")
 
@@ -611,11 +616,13 @@ func main() {
 	}
 
 	go func() {
-		for range time.Tick(5 * time.Second) {
-			updateStatus()
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
+		for range ticker.C {
+			fyne.Do(func() { updateStatus() })
 		}
 	}()
-	updateStatus()
+	fyne.Do(func() { updateStatus() })
 
 	// Layout
 	statusBox := container.NewVBox(


### PR DESCRIPTION
## Summary
- avoid leaking tickers and ensure status updates are run on the main thread
- log any panic to file so crashes are visible

## Testing
- `gofmt -w cmd/win-gui/main.go`
- `GOOS=windows go vet ./cmd/win-gui` *(fails: build constraints exclude all Go files in github.com/go-gl/gl)*

------
https://chatgpt.com/codex/tasks/task_e_685373070d04832ab48a4e52395aadf0